### PR TITLE
Format sought instance string with cls.name for bugfix

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -77,7 +77,7 @@ class DBStorage:
 
     def get(self, cls, id):
         """return object based on input parameters"""
-        keyString = ("{}.{}".format(cls, id))
+        keyString = ("{}.{}".format(cls.__name__, id))
         if keyString in self.all(cls).keys():
             return self.all(cls)[keyString]
         else:

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -71,7 +71,7 @@ class FileStorage:
 
     def get(self, cls, id):
         """return object based on input parameters"""
-        keyString = ("{}.{}".format(cls, id))
+        keyString = ("{}.{}".format(cls.__name__, id))
         if keyString in self.all(cls).keys():
             return self.all(cls)[keyString]
         else:


### PR DESCRIPTION
Storage queries were not successful because the keyString sought from the .all() dictionary was using the class instance rather than the class name.